### PR TITLE
Specify that no fields are to be excluded in PayPalIPNForm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 /build
 /django_paypal.egg-info
 *.swp
+
+.idea/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 Django PayPal
 =============
 
+Note: Due to changes in the way signals are sent out, this branch may not be backwards
+compatible with either `dcramer/django-paypal` or `johnboxall/django-paypal`
+versions. (see the signals section below)
+
+Please report any issues to the repo of the version you are using.
 
 About
 -----
@@ -19,9 +24,21 @@ There is currently an active discussion over the handling of some of the finer p
 Using PayPal Payments Standard IPN:
 -------------------------------
 
-1. Download the code from GitHub:
+1. Download or install the code from GitHub:
 
-        git clone git://github.com/johnboxall/django-paypal.git paypal
+        git clone git://github.com/poswald/django-paypal.git paypal
+
+   If you are building with pip/virtualenv you may use that to install using an editable version
+   directly from github. This is the reccomended way of using the project:
+
+        pip install -e git+git://github.com/poswald/django-paypal.git@master#egg=django-paypal
+
+   you can also add a line like the following into your requirements.txt:
+
+        -e git+git://github.com/poswald/django-paypal.git@master#egg=django-paypal
+
+   notice that you can specify a branch or a specific commit if you want.
+
 
 1. Edit `settings.py` and add  `paypal.standard.ipn` to your `INSTALLED_APPS`
    and `PAYPAL_RECEIVER_EMAIL`:
@@ -106,9 +123,20 @@ Using PayPal Payments Standard IPN:
 
     There are two ipn messages that are not well documented by paypal but
     sometimes get sent. These are recurring ipn messages (they have a Recurring
-    Payment ID), but they have also been seen sent out for subscriptions.
+    Payment ID), but they have also been seen sent out for subscriptions. Signals
+    when these come in is not yet supported:
     - `recurring_payment_outstanding_payment`
     - `recurring_payment_suspended_due_to_max_failed_payment`
+
+
+    Note: previous versions of this project would send out the
+    `payment_was_successful` signal for any ipn with a `txn_id` set. This means
+    that a one-off purchase, a recurring payment and a subscription payment
+    would all fire the same signal. Payments for subscriptions have both
+    the `txn_id` and the `subscr_id` set. This version of the project will only
+    send out `payment_was_successful` for purchases, not subscription or
+    recurring payments. You can use `recurring_payment` or `subscription_payment`
+    for those.
 
 
     Connect to these signals and update your data accordingly. [Django Signals Documentation](http://docs.djangoproject.com/en/dev/topics/signals/).

--- a/README.md
+++ b/README.md
@@ -79,25 +79,37 @@ Using PayPal Payments Standard IPN:
 
 1.  Whenever an IPN is processed a signal will be sent with the result of the
     transaction. Connect the signals to actions to perform the needed operations
-    when a successful payment is recieved.
+    when an event occurs.
 
-    There are two signals for basic transactions:
+    Signals for basic transactions:
     - `payment_was_successful`
     - `payment_was_flagged`
+    - `payment_refunded`
 
-    And five signals for subscriptions:
+    Signals for subscriptions:
     - `subscription_cancel` - Sent when a subscription is cancelled.
     - `subscription_eot` - Sent when a subscription expires.
     - `subscription_modify` - Sent when a subscription is modified.
     - `subscription_signup` - Sent when a subscription is created.
     - `subscription_failed` - Sent when a subscription payment fails. Paypal may still retry it.
+    - `subscription_payment` - When a subscription payment is received from a subscription
 
-    Several more exist for recurring payments:
+    Signals for recurring payments:
     - `recurring_create` - Sent when a recurring payment is created.
     - `recurring_payment` - Sent when a payment is received from a recurring payment.
     - `recurring_cancel` - Sent when a recurring payment is cancelled.
     - `recurring_suspend` - Sent when a recurring payment is suspended.
     - `recurring_reactivate` - Sent when a recurring payment is reactivated.
+    - `recurring_skipped`
+    - `recurring_refunded`
+    - `recurring_failed`
+
+    There are two ipn messages that are not well documented by paypal but
+    sometimes get sent. These are recurring ipn messages (they have a Recurring
+    Payment ID), but they have also been seen sent out for subscriptions.
+    - `recurring_payment_outstanding_payment`
+    - `recurring_payment_suspended_due_to_max_failed_payment`
+
 
     Connect to these signals and update your data accordingly. [Django Signals Documentation](http://docs.djangoproject.com/en/dev/topics/signals/).
 
@@ -328,9 +340,20 @@ apps.
             (r'^some/obscure/name/', include('paypal.standard.ipn.urls')),
         )
 
-7. Connect to the provided signals and have them do something useful:
+7. Connect to the provided signals and have them do something useful. There are
+   additional signals defined in the `paypal.pro.models.signals` module. These
+   signals are different from IPN signals in that they are sent the second the
+   payment is failed or succeeds and come with the `item` object passed to
+   PayPalPro rather than an IPN object:
+
     - `payment_was_successful`
     - `payment_was_flagged`
+
+    - `payment_profile_created`
+    - `recurring_cancel`
+    - `recurring_suspend`
+    - `recurring_reactivate`
+
 
 
 8. Profit.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Django PayPal
 About
 -----
 
-Django PayPal is a pluggable application that implements with PayPal Payments 
+Django PayPal is a pluggable application that implements with PayPal Payments
 Standard and Payments Pro.
 
 Before diving in, a quick review of PayPal's payment methods is in order! [PayPal Payments Standard](https://cms.paypal.com/cms_content/US/en_US/files/developer/PP_WebsitePaymentsStandard_IntegrationGuide.pdf) is the "Buy it Now" buttons you may have
@@ -23,7 +23,7 @@ Using PayPal Payments Standard IPN:
 
         git clone git://github.com/johnboxall/django-paypal.git paypal
 
-1. Edit `settings.py` and add  `paypal.standard.ipn` to your `INSTALLED_APPS` 
+1. Edit `settings.py` and add  `paypal.standard.ipn` to your `INSTALLED_APPS`
    and `PAYPAL_RECEIVER_EMAIL`:
 
         # settings.py
@@ -32,16 +32,16 @@ Using PayPal Payments Standard IPN:
         ...
         PAYPAL_RECEIVER_EMAIL = "yourpaypalemail@example.com"
 
-1.  Create an instance of the `PayPalPaymentsForm` in the view where you would 
-    like to collect money. Call `render` on the instance in your template to 
+1.  Create an instance of the `PayPalPaymentsForm` in the view where you would
+    like to collect money. Call `render` on the instance in your template to
     write out the HTML.
 
         # views.py
         ...
         from paypal.standard.forms import PayPalPaymentsForm
-        
+
         def view_that_asks_for_money(request):
-        
+
             # What you want the button to do.
             paypal_dict = {
                 "business": "yourpaypalemail@example.com",
@@ -51,24 +51,24 @@ Using PayPal Payments Standard IPN:
                 "notify_url": "http://www.example.com/your-ipn-location/",
                 "return_url": "http://www.example.com/your-return-location/",
                 "cancel_return": "http://www.example.com/your-cancel-location/",
-            
+
             }
-            
+
             # Create the instance.
             form = PayPalPaymentsForm(initial=paypal_dict)
             context = {"form": form}
             return render_to_response("payment.html", context)
-            
-            
+
+
         <!-- payment.html -->
         ...
         <h1>Show me the money!</h1>
         <!-- writes out the form tag automatically -->
         {{ form.render }}
 
-1.  When someone uses this button to buy something PayPal makes a HTTP POST to 
-    your "notify_url". PayPal calls this Instant Payment Notification (IPN). 
-    The view `paypal.standard.ipn.views.ipn` handles IPN processing. To set the 
+1.  When someone uses this button to buy something PayPal makes a HTTP POST to
+    your "notify_url". PayPal calls this Instant Payment Notification (IPN).
+    The view `paypal.standard.ipn.views.ipn` handles IPN processing. To set the
     correct `notify_url` add the following to your `urls.py`:
 
         # urls.py
@@ -77,19 +77,20 @@ Using PayPal Payments Standard IPN:
             (r'^something/hard/to/guess/', include('paypal.standard.ipn.urls')),
         )
 
-1.  Whenever an IPN is processed a signal will be sent with the result of the 
+1.  Whenever an IPN is processed a signal will be sent with the result of the
     transaction. Connect the signals to actions to perform the needed operations
     when a successful payment is recieved.
-    
+
     There are two signals for basic transactions:
-    - `payment_was_successful` 
+    - `payment_was_successful`
     - `payment_was_flagged`
-    
-    And four signals for subscriptions:
+
+    And five signals for subscriptions:
     - `subscription_cancel` - Sent when a subscription is cancelled.
     - `subscription_eot` - Sent when a subscription expires.
     - `subscription_modify` - Sent when a subscription is modified.
     - `subscription_signup` - Sent when a subscription is created.
+    - `subscription_failed` - Sent when a subscription payment fails. Paypal may still retry it.
 
     Several more exist for recurring payments:
     - `recurring_create` - Sent when a recurring payment is created.
@@ -103,15 +104,15 @@ Using PayPal Payments Standard IPN:
         # models.py
         ...
         from paypal.standard.ipn.signals import payment_was_successful
-        
+
         def show_me_the_money(sender, **kwargs):
             ipn_obj = sender
             # Undertake some action depending upon `ipn_obj`.
             if ipn_obj.custom == "Upgrade all users!":
-                Users.objects.update(paid=True)        
+                Users.objects.update(paid=True)
         payment_was_successful.connect(show_me_the_money)
-        
-        
+
+
 Using PayPal Payments Standard PDT:
 -----------------------------------
 
@@ -126,13 +127,13 @@ Paypal Payment Data Transfer (PDT) allows you to display transaction details to 
         # settings.py
         ...
         INSTALLED_APPS = (... 'paypal.standard.pdt', ...)
-        
+
         PAYPAL_IDENTITY_TOKEN = "xxx"
 
 1.  Create a view that uses `PayPalPaymentsForm` just like in PayPal IPN.
 
-1.  After someone uses this button to buy something PayPal will return the user to your site at 
-    your "return_url" with some extra GET parameters. PayPal calls this Payment Data Transfer (PDT). 
+1.  After someone uses this button to buy something PayPal will return the user to your site at
+    your "return_url" with some extra GET parameters. PayPal calls this Payment Data Transfer (PDT).
     The view `paypal.standard.pdt.views.pdt` handles PDT processing. to specify the correct
      `return_url` add the following to your `urls.py`:
 
@@ -146,7 +147,7 @@ Paypal Payment Data Transfer (PDT) allows you to display transaction details to 
 Using PayPal Payments Standard with Subscriptions:
 --------------------------------------------------
 
-1.  For subscription actions, you'll need to add a parameter to tell it to use the subscription buttons and the command, plus any 
+1.  For subscription actions, you'll need to add a parameter to tell it to use the subscription buttons and the command, plus any
     subscription-specific settings:
 
         # views.py
@@ -154,7 +155,7 @@ Using PayPal Payments Standard with Subscriptions:
         paypal_dict = {
             "cmd": "_xclick-subscriptions",
             "business": "your_account@paypal",
-            "a3": "9.99",                      # monthly price 
+            "a3": "9.99",                      # monthly price
             "p3": 1,                           # duration of each unit (depends on unit)
             "t3": "M",                         # duration unit ("M for Month")
             "src": "1",                        # make payments recur
@@ -168,7 +169,7 @@ Using PayPal Payments Standard with Subscriptions:
 
         # Create the instance.
         form = PayPalPaymentsForm(initial=paypal_dict, button_type="subscribe")
-        
+
         # Output the button.
         form.render()
 
@@ -181,7 +182,7 @@ Use this method to encrypt your button so sneaky gits don't try to hack it. Than
 1. Encrypted buttons require the `M2Crypto` library:
 
         easy_install M2Crypto
-    
+
 
 1. Encrypted buttons require certificates. Create a private key:
 
@@ -192,7 +193,7 @@ Use this method to encrypt your button so sneaky gits don't try to hack it. Than
         openssl req -new -key paypal.pem -x509 -days 365 -out pubpaypal.pem
 
 1. Upload your public key to the paypal website (sandbox or live).
-        
+
     [https://www.paypal.com/us/cgi-bin/webscr?cmd=_profile-website-cert](https://www.paypal.com/us/cgi-bin/webscr?cmd=_profile-website-cert)
 
     [https://www.paypal.com/us/cgi-bin/webscr?cmd=_profile-website-cert](https://www.sandbox.paypal.com/us/cgi-bin/webscr?cmd=_profile-website-cert)
@@ -214,7 +215,7 @@ Use this method to encrypt your button so sneaky gits don't try to hack it. Than
 
         # views.py
         from paypal.standard.forms import PayPalEncryptedPaymentsForm
-        
+
         def view_that_asks_for_money(request):
             ...
             # Create the instance.
@@ -229,42 +230,42 @@ Using PayPal Payments Standard with Encrypted Buttons and Shared Secrets:
 This method uses Shared secrets instead of IPN postback to verify that transactions
 are legit. PayPal recommends you should use Shared Secrets if:
 
-    * You are not using a shared website hosting service. 
-    * You have enabled SSL on your web server. 
-    * You are using Encrypted Website Payments. 
+    * You are not using a shared website hosting service.
+    * You have enabled SSL on your web server.
+    * You are using Encrypted Website Payments.
     * You use the notify_url variable on each individual payment transaction.
-    
-Use postbacks for validation if: 
-    * You rely on a shared website hosting service 
-    * You do not have SSL enabled on your web server 
+
+Use postbacks for validation if:
+    * You rely on a shared website hosting service
+    * You do not have SSL enabled on your web server
 
 1. Swap out your button for a `PayPalSharedSecretEncryptedPaymentsForm`:
 
         # views.py
         from paypal.standard.forms import PayPalSharedSecretEncryptedPaymentsForm
-        
+
         def view_that_asks_for_money(request):
             ...
             # Create the instance.
             form = PayPalSharedSecretEncryptedPaymentsForm(initial=paypal_dict)
             # Works just like before!
             form.render()
-            
+
 1. Verify that your IPN endpoint is running on SSL - `request.is_secure()` should return `True`!
 
 
 Using PayPal Payments Pro (WPP)
 -------------------------------
 
-WPP is the more awesome version of PayPal that lets you accept payments on your 
-site. WPP reuses code from `paypal.standard` so you'll need to include both 
+WPP is the more awesome version of PayPal that lets you accept payments on your
+site. WPP reuses code from `paypal.standard` so you'll need to include both
 apps.
 
 1. Obtain PayPal Pro API credentials: login to PayPal, click *My Account*,
   *Profile*, *Request API credentials*, *Set up PayPal API credentials and
   permissions*, *View API Signature*.
 
-2. Edit `settings.py` and add  `paypal.standard` and `paypal.pro` to your 
+2. Edit `settings.py` and add  `paypal.standard` and `paypal.pro` to your
    `INSTALLED_APPS` and put in your PayPal Pro API credentials.
 
         # settings.py
@@ -288,18 +289,18 @@ apps.
                   "custom": "tracking",       # custom tracking variable for you
                   "cancelurl": "http://...",  # Express checkout cancel url
                   "returnurl": "http://..."}  # Express checkout return url
-        
+
           kw = {"item": item,                            # what you're selling
                 "payment_template": "payment.html",      # template name for payment
                 "confirm_template": "confirmation.html", # template name for confirmation
                 "success_url": "/success/"}              # redirect location after success
-                
+
           ppp = PayPalPro(**kw)
           return ppp(request)
 
 
-5. Create templates for payment and confirmation. By default both templates are 
-   populated with the context variable `form` which contains either a 
+5. Create templates for payment and confirmation. By default both templates are
+   populated with the context variable `form` which contains either a
    `PaymentForm` or a `Confirmation` form.
 
         <!-- payment.html -->
@@ -308,7 +309,7 @@ apps.
           {{ form }}
           <input type="submit" value="Pay Up">
         </form>
-        
+
         <!-- confirmation.html -->
         <h1>Are you sure you want to buy this thing?</h1>
         <form method="post" action="">
@@ -316,7 +317,7 @@ apps.
           <input type="submit" value="Yes I Yams">
         </form>
 
-6. Add your view to `urls.py`, and add the IPN endpoint to receive callbacks 
+6. Add your view to `urls.py`, and add the IPN endpoint to receive callbacks
    from PayPal:
 
         # urls.py
@@ -328,7 +329,7 @@ apps.
         )
 
 7. Connect to the provided signals and have them do something useful:
-    - `payment_was_successful` 
+    - `payment_was_successful`
     - `payment_was_flagged`
 
 

--- a/paypal/pro/helpers.py
+++ b/paypal/pro/helpers.py
@@ -190,7 +190,13 @@ class PayPalWPP(object):
         return nvp_obj
         
     def refundTransaction(self, params):
-        raise NotImplementedError
+        defaults = {"method": "refundTransaction", "refundtype": 'Full'}
+        required = L("transactionid")
+
+        nvp_obj = self._fetch(params, required, defaults)
+        if nvp_obj.flag:
+            raise PayPalFailure(nvp_obj.flag_info)
+        return nvp_obj
 
     def _is_recurring(self, params):
         """Returns True if the item passed is a recurring transaction."""

--- a/paypal/standard/forms.py
+++ b/paypal/standard/forms.py
@@ -9,13 +9,15 @@ from paypal.standard.conf import (POSTBACK_ENDPOINT, SANDBOX_POSTBACK_ENDPOINT,
     RECEIVER_EMAIL, TEST)
 
 
-# 20:18:05 Jan 30, 2009 PST - PST timezone support is not included out of the box.
-# PAYPAL_DATE_FORMAT = ("%H:%M:%S %b. %d, %Y PST", "%H:%M:%S %b %d, %Y PST",)
 # PayPal dates have been spotted in the wild with these formats, beware!
-PAYPAL_DATE_FORMAT = ("%H:%M:%S %b. %d, %Y PST",
-                      "%H:%M:%S %b. %d, %Y PDT",
-                      "%H:%M:%S %b %d, %Y PST",
-                      "%H:%M:%S %b %d, %Y PDT",)
+# Input formats use python string formatting:
+# http://docs.python.org/2/library/datetime.html#strftime-strptime-behavior
+PAYPAL_DATE_FORMAT = (
+    "%H:%M:%S %b. %d, %Y PST", # 20:18:05 Jan. 30, 2009 PST
+    "%H:%M:%S %b. %d, %Y PDT", # 20:18:05 Jan. 30, 2009 PDT
+    "%H:%M:%S %b %d, %Y PST",  # 20:18:05 Jan 30, 2009 PST
+    "%H:%M:%S %b %d, %Y PDT",  # 20:18:05 Jan 30, 2009 PDT
+    )
 
 class PayPalPaymentsForm(forms.Form):
     """
@@ -214,3 +216,4 @@ class PayPalStandardBaseForm(forms.ModelForm):
     next_payment_date = forms.DateTimeField(required=False, input_formats=PAYPAL_DATE_FORMAT)
     subscr_date = forms.DateTimeField(required=False, input_formats=PAYPAL_DATE_FORMAT)
     subscr_effective = forms.DateTimeField(required=False, input_formats=PAYPAL_DATE_FORMAT)
+    retry_at = forms.DateTimeField(required=False, input_formats=PAYPAL_DATE_FORMAT)

--- a/paypal/standard/forms.py
+++ b/paypal/standard/forms.py
@@ -168,7 +168,7 @@ class PayPalEncryptedPaymentsForm(PayPalPaymentsForm):
         s = SMIME.SMIME()
         s.load_key_bio(BIO.openfile(CERT), BIO.openfile(PUB_CERT))
         p7 = s.sign(BIO.MemoryBuffer(plaintext), flags=SMIME.PKCS7_BINARY)
-        x509 = X509.load_cert_bio(BIO.openfile(settings.PAYPAL_CERT))
+        x509 = X509.load_cert_bio(BIO.openfile(PAYPAL_CERT))
         sk = X509.X509_Stack()
         sk.push(x509)
         s.set_x509_stack(sk)

--- a/paypal/standard/ipn/admin.py
+++ b/paypal/standard/ipn/admin.py
@@ -10,8 +10,8 @@ class PayPalIPNAdmin(admin.ModelAdmin):
         (None, {
             "fields": [
                 "flag", "txn_id", "txn_type", "payment_status", "payment_date",
-                "transaction_entity", "reason_code", "pending_reason", 
-                "mc_gross", "mc_fee", "auth_status", "auth_amount", "auth_exp", 
+                "transaction_entity", "reason_code", "pending_reason",
+                "mc_gross", "mc_fee", "auth_status", "auth_amount", "auth_exp",
                 "auth_id"
             ]
         }),
@@ -20,7 +20,7 @@ class PayPalIPNAdmin(admin.ModelAdmin):
             'classes': ('collapse',),
             "fields": [
                 "address_city", "address_country", "address_country_code",
-                "address_name", "address_state", "address_status", 
+                "address_name", "address_state", "address_status",
                 "address_street", "address_zip"
             ]
         }),
@@ -36,34 +36,59 @@ class PayPalIPNAdmin(admin.ModelAdmin):
             "description": "The information about the Seller.",
             'classes': ('collapse',),
             "fields": [
-                "business", "item_name", "item_number", "quantity", 
+                "business", "item_name", "item_number", "quantity",
                 "receiver_email", "receiver_id", "custom", "invoice", "memo"
             ]
         }),
         ("Recurring", {
-            "description": "Information about recurring Payments.",
+            "description": "Information about Recurring Payments.",
             "classes": ("collapse",),
             "fields": [
-                "profile_status", "initial_payment_amount", "amount_per_cycle", 
-                "outstanding_balance", "period_type", "product_name", 
-                "product_type", "recurring_payment_id", "receipt_id", 
+                "profile_status", "initial_payment_amount", "amount_per_cycle",
+                "outstanding_balance", "period_type", "product_name",
+                "product_type", "recurring_payment_id", "receipt_id",
                 "next_payment_date"
+            ]
+        }),
+        ("Subscription", {
+            "description": "Information about Subscriptions.",
+            "classes": ("collapse",),
+            "fields": [
+                "amount1",
+                "amount2",
+                "amount3",
+                "mc_amount1",
+                "mc_amount2",
+                "mc_amount3",
+                #"password",
+                "period1",
+                "period2",
+                "period3",
+                "reattempt",
+                "recur_times",
+                "recurring",
+                "retry_at",
+                "subscr_date",
+                "subscr_effective",
+                "subscr_id",
+                "username",
             ]
         }),
         ("Admin", {
             "description": "Additional Info.",
             "classes": ('collapse',),
             "fields": [
-                "test_ipn", "ipaddress", "query", "response", "flag_code", 
+                "test_ipn", "ipaddress", "query", "response", "flag_code",
                 "flag_info"
             ]
         }),
     )
     list_display = [
-        "__unicode__", "flag", "flag_info", "invoice", "custom", 
+        "__unicode__", "flag", "flag_info", "invoice", "custom",
         "payment_status", "created_at"
     ]
-    search_fields = ["txn_id", "recurring_payment_id"]
+    search_fields = ["txn_id", "recurring_payment_id", "subscr_id",]
+
 
 
 admin.site.register(PayPalIPN, PayPalIPNAdmin)

--- a/paypal/standard/ipn/models.py
+++ b/paypal/standard/ipn/models.py
@@ -53,6 +53,8 @@ class PayPalIPN(PayPalStandardBase):
                 subscription_cancel.send(sender=self)
             elif self.is_subscription_signup():
                 subscription_signup.send(sender=self)
+            elif self.is_subscription_payment():
+                subscription_payment.send(sender=self)
             elif self.is_subscription_end_of_term():
                 subscription_eot.send(sender=self)
             elif self.is_subscription_modified():

--- a/paypal/standard/ipn/models.py
+++ b/paypal/standard/ipn/models.py
@@ -24,7 +24,7 @@ class PayPalIPN(PayPalStandardBase):
     def send_signals(self):
         """Shout for the world to hear whether a txn was successful."""
         # Transaction signals:
-        if self.is_transaction() and not self.is_recurring():
+        if self.is_transaction() and not self.is_recurring() and not self.is_subscription():
             if self.flag:
                 payment_was_flagged.send(sender=self)
             elif self.is_refund():
@@ -32,7 +32,6 @@ class PayPalIPN(PayPalStandardBase):
             else:
                 payment_was_successful.send(sender=self)
         # Recurring payment signals:
-        # XXX: Should these be merged with subscriptions?
         elif self.is_recurring():
             if self.is_recurring_create():
                 recurring_create.send(sender=self)

--- a/paypal/standard/ipn/models.py
+++ b/paypal/standard/ipn/models.py
@@ -24,9 +24,11 @@ class PayPalIPN(PayPalStandardBase):
     def send_signals(self):
         """Shout for the world to hear whether a txn was successful."""
         # Transaction signals:
-        if self.is_transaction():
+        if self.is_transaction() and not self.is_recurring():
             if self.flag:
                 payment_was_flagged.send(sender=self)
+            elif self.is_refund():
+                payment_refunded.send(sender=self)
             else:
                 payment_was_successful.send(sender=self)
         # Recurring payment signals:
@@ -42,6 +44,10 @@ class PayPalIPN(PayPalStandardBase):
                 recurring_skipped.send(sender=self)
             elif self.is_recurring_failed():
                 recurring_failed.send(sender=self)
+            elif self.is_refund():
+                recurring_refunded.send(sender=self)
+
+
        # Subscription signals:
         else:
             if self.is_subscription_cancellation():

--- a/paypal/standard/ipn/models.py
+++ b/paypal/standard/ipn/models.py
@@ -57,4 +57,6 @@ class PayPalIPN(PayPalStandardBase):
             elif self.is_subscription_end_of_term():
                 subscription_eot.send(sender=self)
             elif self.is_subscription_modified():
-                subscription_modify.send(sender=self)            
+                subscription_modify.send(sender=self)
+            elif self.is_subscription_failed():
+                subscription_failed.send(sender=self)

--- a/paypal/standard/ipn/signals.py
+++ b/paypal/standard/ipn/signals.py
@@ -12,6 +12,9 @@ payment_was_successful = Signal()
 # Sent when a payment is flagged.
 payment_was_flagged = Signal()
 
+# Sent when a payment is refunded
+payment_refunded = Signal()
+
 # Sent when a subscription was cancelled.
 subscription_cancel = Signal()
 
@@ -33,5 +36,7 @@ recurring_payment = Signal()
 recurring_cancel = Signal()
 
 recurring_skipped = Signal()
+
+recurring_refunded = Signal()
 
 recurring_failed = Signal()

--- a/paypal/standard/ipn/signals.py
+++ b/paypal/standard/ipn/signals.py
@@ -15,6 +15,7 @@ payment_was_flagged = Signal()
 # Sent when a payment is refunded
 payment_refunded = Signal()
 
+
 # Sent when a subscription was cancelled.
 subscription_cancel = Signal()
 
@@ -29,6 +30,8 @@ subscription_signup = Signal()
 
 # Sent when a subscription payment fails
 subscription_failed = Signal()
+
+subscription_payment = Signal()
 
 
 # recurring_payment_profile_created

--- a/paypal/standard/ipn/signals.py
+++ b/paypal/standard/ipn/signals.py
@@ -27,6 +27,10 @@ subscription_modify = Signal()
 # Sent when a subscription is created.
 subscription_signup = Signal()
 
+# Sent when a subscription payment fails
+subscription_failed = Signal()
+
+
 # recurring_payment_profile_created
 recurring_create = Signal()
 

--- a/paypal/standard/ipn/tests/test_ipn.py
+++ b/paypal/standard/ipn/tests/test_ipn.py
@@ -29,7 +29,7 @@ IPN_POST_PARAMS = {
     "txn_type": "express_checkout",
     "handling_amount": "0.00",
     "payment_date": "23:04:06 Feb 02, 2009 PST",
-    "first_name": "Test",
+    "first_name": "J\xF6rg",
     "item_name": "",
     "charset": "windows-1252",
     "custom": "website_id=13&user_id=21",
@@ -119,9 +119,12 @@ class IPNTest(TestCase):
         
         self.assertTrue(self.got_signal)
         self.assertEqual(self.signal_obj, ipn_obj)
+        return ipn_obj
         
     def test_correct_ipn(self):
-        self.assertGotSignal(payment_was_successful, False)
+        ipn_obj = self.assertGotSignal(payment_was_successful, False)
+        # Check some encoding issues:
+        self.assertEqual(ipn_obj.first_name, u"J\u00f6rg")
 
     def test_failed_ipn(self):
         PayPalIPN._postback = lambda self: "INVALID"

--- a/paypal/standard/ipn/tests/test_urls.py
+++ b/paypal/standard/ipn/tests/test_urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 
 urlpatterns = patterns('paypal.standard.ipn.views',
     (r'^ipn/$', 'ipn'),

--- a/paypal/standard/ipn/urls.py
+++ b/paypal/standard/ipn/urls.py
@@ -1,5 +1,5 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 
-urlpatterns = patterns('paypal.standard.ipn.views',            
+urlpatterns = patterns('paypal.standard.ipn.views',
     url(r'^$', 'ipn', name="paypal-ipn"),
 )

--- a/paypal/standard/ipn/views.py
+++ b/paypal/standard/ipn/views.py
@@ -36,7 +36,7 @@ def ipn(request, item_check_callable=None):
     else:
         try:
             # get a mutable copy of the data in the correct encoding
-            data = QueryDict(request.raw_post_data, encoding=encoding).copy()
+            data = QueryDict(request.body, encoding=encoding).copy()
         except LookupError:
             data = None
             flag = "Invalid form - invalid charset"

--- a/paypal/standard/ipn/views.py
+++ b/paypal/standard/ipn/views.py
@@ -26,7 +26,7 @@ def ipn(request, item_check_callable=None):
     # Clean up the data as PayPal sends some weird values such as "N/A"
     data = request.POST.copy()
     date_fields = ('time_created', 'payment_date', 'next_payment_date',
-                   'subscr_date', 'subscr_effective')
+                   'subscr_date', 'subscr_effective', 'retry_at')
     for date_field in date_fields:
         if data.get(date_field) == 'N/A':
             del data[date_field]

--- a/paypal/standard/ipn/views.py
+++ b/paypal/standard/ipn/views.py
@@ -35,7 +35,8 @@ def ipn(request, item_check_callable=None):
         data = None
     else:
         try:
-            data = QueryDict(request.raw_post_data, encoding=encoding)
+            # get a mutable copy of the data in the correct encoding
+            data = QueryDict(request.raw_post_data, encoding=encoding).copy()
         except LookupError:
             data = None
             flag = "Invalid form - invalid charset"

--- a/paypal/standard/models.py
+++ b/paypal/standard/models.py
@@ -176,8 +176,8 @@ class PayPalStandardBase(Model):
     flag = models.BooleanField(default=False, blank=True)
     flag_code = models.CharField(max_length=16, blank=True)
     flag_info = models.TextField(blank=True)
-    query = models.TextField(blank=True)  # What we sent to PayPal.
-    response = models.TextField(blank=True)  # What we got back.
+    query = models.TextField(blank=True)  # What Paypal sent to us initially
+    response = models.TextField(blank=True)  # What we got back from our request
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 

--- a/paypal/standard/models.py
+++ b/paypal/standard/models.py
@@ -306,7 +306,12 @@ class PayPalStandardBase(Model):
 
     def initialize(self, request):
         """Store the data we'll need to make the postback from the request object."""
-        self.query = getattr(request, request.method).urlencode()
+        if request.method == 'GET':
+            # PDT only - this data is currently unused
+            self.query = request.META.get('QUERY_STRING', '')
+        elif request.method == 'POST':
+            # The following works if paypal sends an ASCII bytestring, which it does.
+            self.query = request.raw_post_data
         self.ipaddress = request.META.get('REMOTE_ADDR', '')
 
     def _postback(self):

--- a/paypal/standard/models.py
+++ b/paypal/standard/models.py
@@ -191,24 +191,29 @@ class PayPalStandardBase(Model):
     def __unicode__(self):
         if self.is_transaction():
             return self.format % ("Transaction", self.txn_id)
-        else:
+        elif self.is_recurring():
             return self.format % ("Recurring", self.recurring_payment_id)
-        
+        else:
+            return self.format % ("Subscription", self.subscr_id)
+
     def is_transaction(self):
         return len(self.txn_id) > 0
 
     def is_recurring(self):
         return len(self.recurring_payment_id) > 0
-    
+
+    def is_subscription(self):
+        return len(self.subscr_id) > 0
+
     def is_subscription_cancellation(self):
         return self.txn_type == "subscr_cancel"
-    
+
     def is_subscription_end_of_term(self):
         return self.txn_type == "subscr_eot"
-    
+
     def is_subscription_modified(self):
         return self.txn_type == "subscr_modify"
-    
+
     def is_subscription_signup(self):
         return self.txn_type == "subscr_signup"
 
@@ -267,9 +272,9 @@ class PayPalStandardBase(Model):
                     if flag:
                         self.set_flag(reason)
             else:
-                # @@@ Run a different series of checks on recurring payments.
+                # @@@ Run a different series of checks on recurring/subscription payments.
                 pass
-        
+
         self.save()
         self.send_signals()
 

--- a/paypal/standard/models.py
+++ b/paypal/standard/models.py
@@ -214,8 +214,6 @@ class PayPalStandardBase(Model):
     def is_transaction(self):
         return len(self.txn_id) > 0
 
-    def is_recurring(self):
-        return len(self.recurring_payment_id) > 0
 
     def is_subscription(self):
         return len(self.subscr_id) > 0
@@ -232,16 +230,23 @@ class PayPalStandardBase(Model):
     def is_subscription_signup(self):
         return self.txn_type == "subscr_signup"
 
+    def is_subscription_payment(self):
+        return self.txn_type == "subscr_payment"
+
     def is_subscription_failed(self):
         # Note this just means the subscription payment failed. Paypal may retry.
         return self.txn_type == "subscr_failed"
+
+
+    def is_recurring(self):
+        return len(self.recurring_payment_id) > 0
 
     def is_recurring_create(self):
         return self.txn_type == "recurring_payment_profile_created"
 
     def is_recurring_payment(self):
         return self.txn_type == "recurring_payment"
-    
+
     def is_recurring_cancel(self):
         return self.txn_type == "recurring_payment_profile_cancel"
 

--- a/paypal/standard/models.py
+++ b/paypal/standard/models.py
@@ -30,7 +30,22 @@ class PayPalStandardBase(Model):
     # @@@ Might want to add all these one distant day.
     # FLAG_CODE_CHOICES = (
     # PAYMENT_STATUS_CHOICES = "Canceled_ Reversal Completed Denied Expired Failed Pending Processed Refunded Reversed Voided".split()
-    PAYMENT_STATUS_CHOICES = (ST_PP_ACTIVE, ST_PP_CANCELLED, ST_PP_CLEARED, ST_PP_COMPLETED, ST_PP_DENIED, ST_PP_PAID, ST_PP_PENDING, ST_PP_PROCESSED, ST_PP_REFUSED, ST_PP_REFUNDED, ST_PP_REVERSED, ST_PP_REWARDED, ST_PP_UNCLAIMED, ST_PP_UNCLEARED)
+    PAYMENT_STATUS_CHOICES = (
+        ST_PP_ACTIVE,
+        ST_PP_CANCELLED,
+        ST_PP_CLEARED,
+        ST_PP_COMPLETED,
+        ST_PP_DENIED,
+        ST_PP_PAID,
+        ST_PP_PENDING,
+        ST_PP_PROCESSED,
+        ST_PP_REFUSED,
+        ST_PP_REFUNDED,
+        ST_PP_REVERSED,
+        ST_PP_REWARDED,
+        ST_PP_UNCLAIMED,
+        ST_PP_UNCLEARED,
+    )
     # AUTH_STATUS_CHOICES = "Completed Pending Voided".split()
     # ADDRESS_STATUS_CHOICES = "confirmed unconfirmed".split()
     # PAYER_STATUS_CHOICES = "verified / unverified".split()

--- a/paypal/standard/models.py
+++ b/paypal/standard/models.py
@@ -14,6 +14,7 @@ ST_PP_PAID = 'Paid'
 ST_PP_PENDING = 'Pending'
 ST_PP_PROCESSED = 'Processed'
 ST_PP_REFUSED = 'Refused'
+ST_PP_REFUNDED = 'Refunded'
 ST_PP_REVERSED = 'Reversed'
 ST_PP_REWARDED = 'Rewarded'
 ST_PP_UNCLAIMED = 'Unclaimed'
@@ -29,7 +30,7 @@ class PayPalStandardBase(Model):
     # @@@ Might want to add all these one distant day.
     # FLAG_CODE_CHOICES = (
     # PAYMENT_STATUS_CHOICES = "Canceled_ Reversal Completed Denied Expired Failed Pending Processed Refunded Reversed Voided".split()
-    PAYMENT_STATUS_CHOICES = (ST_PP_ACTIVE, ST_PP_CANCELLED, ST_PP_CLEARED, ST_PP_COMPLETED, ST_PP_DENIED, ST_PP_PAID, ST_PP_PENDING, ST_PP_PROCESSED, ST_PP_REFUSED, ST_PP_REVERSED, ST_PP_REWARDED, ST_PP_UNCLAIMED, ST_PP_UNCLEARED)
+    PAYMENT_STATUS_CHOICES = (ST_PP_ACTIVE, ST_PP_CANCELLED, ST_PP_CLEARED, ST_PP_COMPLETED, ST_PP_DENIED, ST_PP_PAID, ST_PP_PENDING, ST_PP_PROCESSED, ST_PP_REFUSED, ST_PP_REFUNDED, ST_PP_REVERSED, ST_PP_REWARDED, ST_PP_UNCLAIMED, ST_PP_UNCLEARED)
     # AUTH_STATUS_CHOICES = "Completed Pending Voided".split()
     # ADDRESS_STATUS_CHOICES = "confirmed unconfirmed".split()
     # PAYER_STATUS_CHOICES = "verified / unverified".split()
@@ -118,7 +119,7 @@ class PayPalStandardBase(Model):
     payment_cycle= models.CharField(max_length=32, blank=True) #Monthly
     period_type = models.CharField(max_length=32, blank=True)
     product_name = models.CharField(max_length=128, blank=True)
-    product_type= models.CharField(max_length=128, blank=True)    
+    product_type = models.CharField(max_length=128, blank=True)
     profile_status = models.CharField(max_length=32, blank=True)
     recurring_payment_id = models.CharField(max_length=128, blank=True)  # I-FA4XVST722B9
     rp_invoice_id= models.CharField(max_length=127, blank=True)  # 1335-7816-2936-1451
@@ -219,7 +220,10 @@ class PayPalStandardBase(Model):
     
     def is_recurring_cancel(self):
         return self.txn_type == "recurring_payment_profile_cancel"
-    
+
+    def is_refund(self):
+        return self.reason_code == "refund" # txn_type is not passed on refunds
+
     def is_recurring_skipped(self):
         return self.txn_type == "recurring_payment_skipped"
     

--- a/paypal/standard/models.py
+++ b/paypal/standard/models.py
@@ -318,7 +318,6 @@ class PayPalStandardBase(Model):
         raise NotImplementedError("This should be overridden by IPN or PDT models")
 
 
-
     def initialize(self, request):
         """Store the data we'll need to make the postback from the request object."""
         if request.method == 'GET':
@@ -326,7 +325,7 @@ class PayPalStandardBase(Model):
             self.query = request.META.get('QUERY_STRING', '')
         elif request.method == 'POST':
             # The following works if paypal sends an ASCII bytestring, which it does.
-            self.query = request.raw_post_data
+            self.query = request.body
         self.ipaddress = request.META.get('REMOTE_ADDR', '')
 
     def _postback(self):

--- a/paypal/standard/models.py
+++ b/paypal/standard/models.py
@@ -212,6 +212,10 @@ class PayPalStandardBase(Model):
     def is_subscription_signup(self):
         return self.txn_type == "subscr_signup"
 
+    def is_subscription_failed(self):
+        # Note this just means the subscription payment failed. Paypal may retry.
+        return self.txn_type == "subscr_failed"
+
     def is_recurring_create(self):
         return self.txn_type == "recurring_payment_profile_created"
 

--- a/paypal/standard/models.py
+++ b/paypal/standard/models.py
@@ -295,26 +295,8 @@ class PayPalStandardBase(Model):
     def send_signals(self):
         """Shout for the world to hear whether a txn was successful."""
 
-        # Don't do anything if we're not notifying!
-        if self.from_view != 'notify':
-            return
+        raise NotImplementedError("This should be overridden by IPN or PDT models")
 
-        # Transaction signals:
-        if self.is_transaction():
-            if self.flag:
-                payment_was_flagged.send(sender=self)
-            else:
-                payment_was_successful.send(sender=self)
-        # Subscription signals:
-        else:
-            if self.is_subscription_cancellation():
-                subscription_cancel.send(sender=self)
-            elif self.is_subscription_signup():
-                subscription_signup.send(sender=self)
-            elif self.is_subscription_end_of_term():
-                subscription_eot.send(sender=self)
-            elif self.is_subscription_modified():
-                subscription_modify.send(sender=self) 
 
 
     def initialize(self, request):

--- a/paypal/standard/pdt/tests/test_urls.py
+++ b/paypal/standard/pdt/tests/test_urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 
 urlpatterns = patterns('paypal.standard.pdt.views',
     (r'^pdt/$', 'pdt'),

--- a/paypal/standard/pdt/urls.py
+++ b/paypal/standard/pdt/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 
 urlpatterns = patterns('paypal.standard.pdt.views',
     url(r'^$', 'pdt', name="paypal-pdt"),


### PR DESCRIPTION
From Django 1.8, `ModelForm`s are required either to specify `exclude` or `fields`
